### PR TITLE
The testing code using class(X) == "matrix"  returns an error because…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Important changes to this project will be documented in this file.
 We try to follow [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and we use [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.7] - 2023-02-02
+### Fixed
+- An error was returned in several instances of testing input where class(x) 
+was used to check matrices due to a new behaviour of classes in matrices from 
+R > v4.x. Now `inherits` is used to test matrix classes instead of `class`.
+
 ## [0.4.6] - 2021-12-02
 ### Fixed
 - A bug in the `dBD` example (missing comment character). 
@@ -21,7 +27,7 @@ replicates using the Gaussian quadrature method. Documentation for
 
 ## [0.4.3] - 2020-03-24
 ### Added
-- Function 'dBL' to calculate the kernel density for the birth-death process
+- Function `dBL` to calculate the kernel density for the birth-death process
 with species sampling.
 
 ## [0.4.2] - 2020-03-13

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mcmc3r
 Type: Package
 Title: Tools to work with MCMCTree
-Version: 0.4.6
+Version: 0.4.7
 Date: 2017-05-18
 Authors@R: person("Mario", "dos Reis", email = "mariodosreis@gmail.com", role = c("aut", "cre"))
 	person("Sandra", "Alvarez-Carretero", email = "sandra.ac93@gmail.com", role = c("aut", "cre"))

--- a/R/morpho.R
+++ b/R/morpho.R
@@ -267,7 +267,7 @@ write.morpho <- function( M, filename, c = 0, R = diag( 1, dim( M )[2] ),
     stop( "\nPlease use an object of class \"matrix\" and dimensions \"s x n\" to convert
           into MCMCtree format\n" )
   }
-  if( class( X ) != "matrix" ){
+  if( !inherits( X, "matrix" ) ){
     stop( "\nPlease use an object of class \"matrix\" and dimensions \"s x n\" to convert
           into MCMCtree format\n" )
   }
@@ -322,7 +322,7 @@ write.morpho <- function( M, filename, c = 0, R = diag( 1, dim( M )[2] ),
           upload your estimated correlation matrix together with \"A\"\n")
   }
   #if ( ! missing( A ) & class( A ) != "matrix" ){
-  if ( ! is.null( A ) & class( A ) != "matrix" ){
+  if ( ! is.null( A ) & !inherits( A, "matrix" ) ){
     stop( "\nObject \"A\" needs to be of class \"matrix\"\n" )
   }
     # [ DISABLED BY NOW. IT MIGHT BE TOO TIME CONSUMING WITH LARGE MATRICES ]
@@ -658,7 +658,7 @@ matrix2array <- function( X, coords = c( 2, 3 ) ){
     stop( "\nPlease provide an object of class \"matrix\" with \"s x n\" dimensions, 's' specimens and 'n' characters\n" )
   }
 
-  if ( class( X ) != "matrix" ){
+  if ( !inherits( X, "matrix" )){
     stop( "\nPlease use an object of class \"matrix\"\n" )
   }
 
@@ -1196,7 +1196,7 @@ sim.morpho <- function( tree, n , c = 0, R, ... ) {
 # and symmetric
 .checkCorrMat <- function( R, n ){
 
-  if ( class( R ) != "matrix" ){
+  if ( !inherits( R, "matrix" ) ){
     stop( "\nPlease use a correlation matrix of class \"matrix\"\n" )
   }
 
@@ -1582,7 +1582,7 @@ proc2MCMCtree <- function( data, popdata, sp.data, sp.popdata, filename, coords,
   pop.names <- NULL
 
   # If data and/or popdata are a matrix, convert them into an array
-  if ( class( data ) == "matrix" ){
+  if ( inherits( data, "matrix" ) ){
     data    <- mcmc3r::matrix2array( X = data, coords = coords )
     if( ! is.null( row.names( data ) ) ){
       dat.names <- row.names( data )
@@ -1596,7 +1596,7 @@ proc2MCMCtree <- function( data, popdata, sp.data, sp.popdata, filename, coords,
       dat.names <- paste( "Specimen_", seq(1:length(dimnames( data )[[3]])), sep = "" )
     }
   }
-  if( class( popdata ) == "matrix" ){
+  if( inherits( popdata, "matrix" ) ){
     popdata <- mcmc3r::matrix2array( X = popdata, coords = coords )
     if( ! is.null( row.names( popdata ) ) ){
       pop.names <- row.names( popdata )
@@ -1673,10 +1673,10 @@ proc2MCMCtree <- function( data, popdata, sp.data, sp.popdata, filename, coords,
     stop( "\nPlease provide an object of class \"matrix\" or \"array\" for arguments \"data\" and \"popdata\"\n" )
   }
 
-  if ( class( data ) != "matrix" & class( data ) != "array" ){
+  if ( !inherits( data, "matrix" ) & class( data ) != "array" ){
     stop( "\nPlease provide an object of class \"matrix\" or \"array\" for argument \"data\"\n" )
   }
-  if ( class( popdata ) != "matrix" & class( popdata ) != "array" ){
+  if ( !inherits( popdata, "matrix" ) & class( popdata ) != "array" ){
     stop( "\nPlease provide an object of class \"matrix\" or \"array\" for argument \"popdata\"\n" )
   }
 


### PR DESCRIPTION
The testing code using class(X) == "matrix" returns an error because matrix classes are both matrix and array, which is problematic when using that result inside an `if` clause as such comparison will be of length 2 (class(X) returns "matrix" "array"). Matrices were not also arrays in previous versions of R but this has changed (at least from 4.x). A safe approach is to test inheritance rather than class as suggested in all the tests involving checking that an object is of class "matrix". Using the previous version of class checking prevented running the vignette for reproducing the results with the Carnivora dataset. Both tests and vignette are running with the proposed changes.